### PR TITLE
Add sass-lint configuration

### DIFF
--- a/sass/.sass-lint.yml
+++ b/sass/.sass-lint.yml
@@ -59,6 +59,7 @@ rules:
   no-qualifying-elements:
     - 2
     - allow-element-with-attribute: true
+      allow-element-with-class: true
   no-trailing-whitespace: 2
   no-trailing-zero: 2
   no-transition-all: 2

--- a/sass/.sass-lint.yml
+++ b/sass/.sass-lint.yml
@@ -1,0 +1,106 @@
+files:
+  include: '**/*.s+(a|c)ss'
+  ignore:
+    - 'node_modules/**'
+options:
+  merge-default-rules: false
+rules:
+  attribute-quotes: 2
+  bem-depth: 2
+  border-zero: 2
+  brace-style:
+    - 2
+    - brace-style: '1tbs'
+      allow-single-line: true
+  class-name-format:
+    - 1
+    - convention: hyphenatedbem
+  clean-import-paths:
+    - 2
+    - filename-extension: false
+      leading-underscore: false
+  declarations-before-nesting: 2
+  empty-args: 2
+  empty-line-between-blocks:
+    - 2
+    - allow-single-line-rulesets: true
+  final-newline: 2
+  function-name-format:
+    - 2
+    - convention: hyphenatedlowercase
+  hex-length:
+    - 2
+    - style: short
+  hex-notation:
+    - 2
+    - style: lowercase
+  id-name-format:
+    - 1
+    - convention: hyphenatedbem
+  indentation:
+    - 2
+    - size: 4
+  mixin-name-format:
+    - 2
+    - convention: hyphenatedlowercase
+  nesting-depth:
+    - 2
+    - max-depth: 5
+  no-css-comments: 2
+  no-debug: 2
+  no-duplicate-properties: 2
+  no-empty-rulesets: 2
+  no-important: 1
+  no-invalid-hex: 2
+  no-mergeable-selectors: 2
+  no-misspelled-properties:
+    - 2
+    - extra-properties: []
+  no-qualifying-elements:
+    - 2
+    - allow-element-with-attribute: true
+  no-trailing-whitespace: 2
+  no-trailing-zero: 2
+  no-transition-all: 2
+  no-url-domains: 1
+  no-vendor-prefixes:
+    - 2
+    - ignore-non-standard: true
+  no-warn: 2
+  one-declaration-per-line: 2
+  placeholder-in-extend: 2
+  placeholder-name-format:
+    - 2
+    - convention: hyphenatedbem
+  property-sort-order:
+    - 2
+    - ignore-custom-properties: true
+      order: smacss
+  pseudo-element: 2
+  quotes:
+    - 2
+    - style: single
+  shorthand-values: 2
+  single-line-per-selector: 2
+  space-after-bang:
+    - 2
+    - include: false
+  space-after-colon: 2
+  space-after-comma: 2
+  space-around-operator: 2
+  space-before-bang:
+    - 2
+    - include: true
+  space-before-brace:
+    - 2
+    - include: true
+  space-before-colon: 2
+  space-between-parens:
+    - 2
+    - include: false
+  trailing-semicolon: 2
+  url-quotes: 2
+  variable-name-format:
+    - 2
+    - convention: hyphenatedlowercase
+  zero-unit: 2


### PR DESCRIPTION
Add a sane configuration for linting Sass (both .sass and .scss files).

## Relevant tools:

* [sass-lint](https://www.npmjs.com/package/sass-lint)
* [sass-lint-vue](https://www.npmjs.com/package/sass-lint-vue)

## Rules summary:

* File must end with empty line.
* Use 4 spaces for indentation.
* Use [the one true brace style](https://en.wikipedia.org/wiki/Indentation_style#Variant:_1TBS_.28OTBS.29).
* Single quotes for all strings.
* All statements must end with a semicolon.
* Variable must be hyphenated and lowercased.
* Selectors must be hyphenated and lowercased, or follow [BEM](http://getbem.com/naming/).
* Properties must be grouped and ordered as described in [SMACSS](https://smacss.com/book/formatting#grouping).
* Colours in hex must be lowercased and in short notation where possible.
* Attribute selector must be in quotes (e.g. `input[type='search']`).
* Tag selectors can be only used standalone or with attribute (e.g. `h1`, `button[type='submit']`)
* Border reset via `border: 0`.
* Must not use `!important`.
* No vendor prefixes (use [autoprefixer](https://github.com/postcss/autoprefixer)).
* Shorthands must be used where possible (e.g. `margin: 1em` instead of `margin: 1em 1em`).
* Only placeholders can be used with `@extend`, selectors are forbidden.
* Selectors must not be repeated in the same file.